### PR TITLE
CC/CA 65, not 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This package enables sytax highlight for the CA65 6502 assembler.
 ![screenshot](https://user-images.githubusercontent.com/7003154/170838699-ad94370e-d99e-4c43-bd0c-57cb8addb7c6.png)
 
 ## Full Featured
-Complete support for all macros, 6502 opcodes and control commands as specified by the [CC64 docs](https://cc65.github.io/doc/ca65.html).
+Complete support for all macros, 6502 opcodes and control commands as specified by the [CC65 docs](https://cc65.github.io/doc/ca65.html).
 
 ## Installation
 


### PR DESCRIPTION
As long as you're in there - correct external project reference